### PR TITLE
forward constructor arguments and define eof with `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,26 @@ Installation:
 ## Usage:
 
 ```javascript
-var lineReader = require('line-by-line-promise');
-var file = new lineReader('big_file.txt');
+var LineReader = require('line-by-line-promise');
+var file = new LineReader('big_file.txt');
 
 // Example using co: https://github.com/tj/co
 co(function* () {
     var line;
-    while((line = yield file.readLine())) {
+    // note that eof is defined when `readLine()` yields `null`
+    while((line = yield file.readLine()) !== null) {
         console.log(line);
     }
 });
 
 // Example using bluebird: https://github.com/petkaantonov/bluebird
-(Promise.coroutine(function* () {
+Promise.coroutine(function* () {
     var line;
-    while((line = yield file.readLine())) {
+    // note that eof is defined when `readLine()` yields `null`
+    while((line = yield file.readLine()) !== null) {
         console.log(line);
     }
-}))();
+})();
 ```
 
 ## License:

--- a/example.js
+++ b/example.js
@@ -1,16 +1,18 @@
 'use strict';
 
 var path = require('path');
-var co = require('co');
-var lineReader = require('./index');
+var Bluebird = require('bluebird');
 
-var file = new lineReader(path.resolve('./package.json'));
-co(function* () {
+var LineReader = require('./index');
+
+var file = new LineReader(path.resolve('./package.json'));
+Bluebird.coroutine(function* () {
     var line;
-    while((line = yield file.readLine())) {
+    // note that eof is defined when `readLine()` yields `null`
+    while((line = yield file.readLine()) !== null) {
         console.log(line);
     }
-}).catch(function (err) {
+})().catch(function(err) {
     console.log('Error: ' + err.message);
     return;
 });

--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 'use strict';
 
-var lineReader = require('line-by-line');
+var LineReaderImpl = require('line-by-line');
 
-var LineReader = function (filepath, options) {
-    var self = this;
-    if (1 === arguments.length) {
-        options = {};
-    }
-    options.skipEmptyLines = true;  // Have to set this to be true all the time
-    this._file = new lineReader(filepath, options);
+function LineReader(/* arguments */) {
+    // forward the the arguments to the underlying implementation
+    this._file = (function(args) {
+        function F(args) {
+            return LineReaderImpl.apply(this, args);
+        }
+        F.prototype = LineReaderImpl.prototype;
+        return new F(args);
+    })(arguments);
     this._file.pause();
-};
+}
 
 LineReader.prototype.readLine = function () {
     var self = this;
@@ -22,7 +24,7 @@ LineReader.prototype.readLine = function () {
             self._file.removeAllListeners();
         });
         self._file.once('end', function () {
-            resolve();
+            resolve(null);
             self._file.removeAllListeners();
         });
         self._file.once('error', function (err) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "line-by-line": "^0.1.3"
   },
   "devDependencies": {
-    "co": "^4.5.1",
+    "bluebird": "^2.9.25",
     "jshint": "^2.7.0"
   },
   "name": "line-by-line-promise",


### PR DESCRIPTION
Have `line-by-line-promise`'s LineReader forward the constructor
function arguments to the underying `line-by-line` implementation.  With
this, eof had to be explicitly defined by resolving `null`.  The
examples have been modified and converted to use `bluebird`.
